### PR TITLE
Usability improvements

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -22,11 +22,11 @@ module.exports = grammar({
 
     rules: {
         source_file: $ => seq(
-            repeat($.decl),
+            repeat($._decl),
             repeat($.stmt),
         ),
 
-        decl: $ => choice(
+        _decl: $ => choice(
             $.module_decl,
             $.export_decl,
             $.global_decl,
@@ -43,7 +43,7 @@ module.exports = grammar({
         ),
 
         module_decl: $ => seq('module', $.id, ';'),
-        export_decl: $ => seq('export', '{', repeat($.decl), '}'),
+        export_decl: $ => seq('export', '{', repeat($._decl), '}'),
 
         // A change here over Zeek's parser: we make the combo of init class
         // and initializer jointly optional, instead of individually. Helps

--- a/grammar.js
+++ b/grammar.js
@@ -246,7 +246,7 @@ module.exports = grammar({
 
             seq('(', $.expr, ')'),
             seq('copy', '(', $.expr, ')'),
-            prec_r(seq('hook', $.expr)),
+            prec_r(seq('hook', $.id, '(', optional(list1($.expr, ',')), ')')),
             seq($.expr, '?$', $.id),
             seq('schedule', $.expr, '{', $.event_hdr, '}'),
             seq('function', $.begin_lambda, $.func_body),

--- a/grammar.js
+++ b/grammar.js
@@ -37,6 +37,8 @@ module.exports = grammar({
             $.redef_record_decl,
             $.type_decl,
             $.func_decl,
+            $.hook_decl,
+            $.event_decl,
             $.preproc,
         ),
 
@@ -54,7 +56,6 @@ module.exports = grammar({
         redef_enum_decl: $ => seq('redef', 'enum', $.id, '+=', '{', $.enum_body, '}', ';'),
         redef_record_decl: $ => seq('redef', 'record', $.id, '+=', '{', repeat($.type_spec), '}', optional($.attr_list), ';'),
         type_decl: $ => seq('type', $.id, ':', $.type, optional($.attr_list), ';'),
-        func_decl: $ => seq($.func_hdr, repeat($.preproc), $.func_body),
 
         stmt: $ => choice(
             // TODO: @no-test support
@@ -277,13 +278,12 @@ module.exports = grammar({
             prec(-10, $.integer),
         ),
 
-        func_hdr: $ => choice($.func, $.hook, $.event),
-
         // Precedences here are to avoid ambiguity with related expressions
-        func: $ => prec(1, seq('function', $.id, $.func_params, optional($.attr_list))),
-        hook: $ => prec(1, seq('hook', $.id, $.func_params, optional($.attr_list))),
-        event: $ => seq(optional('redef'), 'event', $.id, $.func_params, optional($.attr_list)),
+        func_decl: $ => prec(1, seq('function', $.id, $.func_params, optional($.attr_list), $._func_body)),
+        hook_decl: $ => prec(1, seq('hook', $.id, $.func_params, optional($.attr_list), $._func_body)),
+        event_decl: $ => seq(optional('redef'), 'event', $.id, $.func_params, optional($.attr_list), $._func_body),
 
+        _func_body: $ => seq(repeat($.preproc), $.func_body),
         func_body: $ => seq('{', optional($.stmt_list), '}'),
 
         // Precedence here is to disambiguate other interpretations of the colon

--- a/grammar.js
+++ b/grammar.js
@@ -190,7 +190,7 @@ module.exports = grammar({
         expr: $ => choice(
             prec_l(7, seq($.expr, '[', $.expr_list, ']')),
             prec_l(7, seq($.expr, $.index_slice)),
-            prec_l(7, seq($.expr, '$', $.id)),
+            prec_l(7, $.field_access),
 
             prec_r(6, seq('|', $.expr, '|')),
             prec_r(6, seq('++', $.expr)),
@@ -247,13 +247,16 @@ module.exports = grammar({
             seq('(', $.expr, ')'),
             seq('copy', '(', $.expr, ')'),
             prec_r(seq('hook', $.id, '(', optional(list1($.expr, ',')), ')')),
-            seq($.expr, '?$', $.id),
+            $.field_check,
             seq('schedule', $.expr, '{', $.event_hdr, '}'),
             seq('function', $.begin_lambda, $.func_body),
 
             // Lower precedence here to favor local-variable statements
             prec_r(-1, seq('local', $.id, '=', $.expr)),
         ),
+
+        field_access: $ => prec_l(seq($.expr, '$', $.id)),
+        field_check: $ => prec_l(seq($.expr, '?$', $.id)),
 
         expr_list: $ => list1($.expr, ','),
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,9 +1,9 @@
 ;; Language features
 ;; -----------------
 
-(event (id) @function)
-(hook (id) @function)
-(func (id) @function)
+(event_decl (id) @function)
+(hook_decl (id) @function)
+(func_decl (id) @function)
 (type) @type
 (attr) @attribute
 


### PR DESCRIPTION
This PR adds some usability improvements which makes it easier to query
the parse tree. I accumulated these while working on
https://github.com/bbannier/zeek-language-server. Since the grammar does
not expose explicitly named `field`s I there still manually traverse the
parse tree a lot so many changes in this PR attempt to make that
simpler.