### PR TITLE
Add missing Zeek script directives, expand Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,8 @@ all: generate
 
 generate:
 	tree-sitter generate
+
+test:
+	$(MAKE) -C test $@
+
+.PHONY : all generate test

--- a/README.md
+++ b/README.md
@@ -37,5 +37,7 @@ shows syntax-highlighted sources.
 
 ## Testing
 
-There's currently no `tree-sitter test` testsuite. Instead, a test driver
-clones the Zeek repository and runs on every Zeek script in the distribution.
+There's currently no `tree-sitter test` testsuite. Instead, a test driver runs
+the parser on every Zeek script in the Zeek distribution, reporting any
+errors. For CI, a Github Action workflow additionally clones the Zeek tree prior
+to running this test, to ensure that those Zeek scripts are available.

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,6 @@
+all: test
+
+test:
+	./parse-zeek-tree.sh
+
+.PHONY : all test


### PR DESCRIPTION
This adds support for `@DIR`, `@FILENAME` (which @rsmmr reported in ckreibich/zeekscript#2), `@load-plugin`, and `@unload`. It also adds Makefiles to simplify running the testsuite, and expands the README to better explain the testing.