### PR TITLE
Allow trailing commas in an initializer list

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -158,8 +158,7 @@ module.exports = grammar({
         init_class: $ => prec_r(choice('=', '+=', '-=')),
 
         init: $ => choice(
-            seq('{', '}'),
-            seq('{', repeat(seq($.expr, ',')), $.expr, '}'),
+            seq('{', optional(list1($.expr, ',', true)), '}'),
             $.expr,
         ),
 


### PR DESCRIPTION
This addresses constructs like this one:

  global foo: set[string] = { "foo", "bar", }

Parsing actually worked before as well, but produced an empty expression after
the trailing comma. This resulted in a tree with nodes tagged as erroneous (at
least in the Python bindings) from this one up to the root.

Includes submodule bump.