### PR TITLE
Fix parsing of "minor" comments

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -359,8 +359,6 @@ module.exports = grammar({
             $.string_directive,
         ),
         
-        minor_comment: $ => /#[^#][^\r\n]*/,
-
         // Zeekygen comments come in three flavors: a head one at the beginning
         // of a script (##!), one that refers to the previous node (##<), and
         // ones that refer to the subsequent one. Note that we skip the final
@@ -368,6 +366,8 @@ module.exports = grammar({
         zeekygen_head_comment: $ => /##![^\r\n]*/,
         zeekygen_prev_comment: $ => /##<[^\r\n]*/,
         zeekygen_next_comment: $ => /##[^\r\n]*/,
+
+        minor_comment: $ => /#[^\r\n]*/,
 
         // We track newlines explicitly -- this gives us the ability to honor
         // existing formatting in select places.
@@ -377,9 +377,9 @@ module.exports = grammar({
     'extras': $ => [
         /[ \t]+/,
         $.nl,
-        $.minor_comment,
         $.zeekygen_head_comment,
         $.zeekygen_prev_comment,
         $.zeekygen_next_comment,
+        $.minor_comment,
     ],
 });


### PR DESCRIPTION
Their pattern accidentally allowed newline characters to slip in if they followed right after the "#", i.e., empty comments could accidentally be parsed by swallowing the subsequent line.

For comparison to Benjamin's. :-)

Resolves #9.