### PR TITLE
Add proper parsing for function calls

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -240,6 +240,7 @@ module.exports = grammar({
             prec_l(1, seq('table', '(', optional($.expr_list), ')', optional($.attr_list))),
             prec_l(1, seq('set', '(', optional($.expr_list), ')', optional($.attr_list))),
             prec_l(1, seq('vector', '(', optional($.expr_list), ')')),
+            prec_l(1, seq($.id, '(', optional($.expr_list), ')')),
             prec_l(1, seq($.expr, '(', optional($.expr_list), ')')),
 
             $.id,

--- a/test/corpus/expressions
+++ b/test/corpus/expressions
@@ -1,0 +1,40 @@
+================================================================================
+Function call
+================================================================================
+
+1;
+f(1);
+f(1) + f(1);
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (nl)
+  (stmt
+    (expr
+      (constant
+        (integer))))
+  (nl)
+  (stmt
+    (expr
+      (id)
+      (expr_list
+        (expr
+          (constant
+            (integer))))))
+  (nl)
+  (stmt
+    (expr
+      (expr
+        (id)
+        (expr_list
+          (expr
+            (constant
+              (integer)))))
+      (expr
+        (id)
+        (expr_list
+          (expr
+            (constant
+              (integer)))))))
+  (nl))


### PR DESCRIPTION
This works around the issue reported in zeek/zeekscript#69.