### PR TITLE
CI: Bump node version in test job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "20"
 
       - run: npm install
 


### PR DESCRIPTION
This job didn't run on PRs so I did not get feedback for it on #18.

The patch here concentrates on getting the CI up-to-date so it can at least run again. The test failure against the Zeek tree seems to be preexisting and simply this parser not keeping pace with upstream changes (in this case: `@pragma push/pop` in random locations, completely unsure how to even implement ts parser support for this).