### PR TITLE
Publish releases to PyPI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,15 @@
+name: Publish package
+
+on:
+  push:
+    tags: ["*"]
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
+jobs:
+  pypi:
+    uses: tree-sitter/workflows/.github/workflows/package-pypi.yml@9d0a482e6185682e43cdcc8a7486a4ff89b05517
+    secrets:
+      PYPI_API_TOKEN: ${{secrets.PYPI_API_TOKEN}}


### PR DESCRIPTION
Since 1c279c4ee8c this package contains everything needed for it to be used on its own, e.g., downstream consumers like
https://github.com/zeek/zeekscript/ can directly depend on this package and would not need to perform manual building of the parser anymore, see zeek/zeekscript#72. The only missing piece, at least in the Python ecosystem, was that before zeek/zeekscript#72 that package would publish wheels so users could install the tool without needing e.g., a C compiler. With parser compilation moved from zeek/zeekscript into tree-sitter-zeek zeekscript does not need to build any wheels anymore (it is a source-only package); instead we should provide wheels for tree-sitter-zeek which this patch implements.

Note: The action I used here can also publish packages for NPM and Rust crates. These ecosystems are much more comfortable with requiring a compiler, so I deliberately did not set this up.