### PR TITLE
Fix version in all relevant locations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-zeek"
 description = "Zeek grammar for tree-sitter"
-version = "0.0.1"
+version = "0.1.0"
 license = "MIT"
 readme = "README.md"
 keywords = ["incremental", "parsing", "tree-sitter", "zeek"]

--- a/README.md
+++ b/README.md
@@ -41,3 +41,15 @@ There's currently no `tree-sitter test` testsuite. Instead, a test driver runs
 the parser on every Zeek script in the Zeek distribution, reporting any
 errors. For CI, a Github Action workflow additionally clones the Zeek tree prior
 to running this test, to ensure that those Zeek scripts are available.
+
+## Releasing a new version
+
+To release a new version update the version number in the following ecosystem-specific files:
+
+- `package.json`: key `version`
+  - `package-lock.json`: update `package.json` and run `npm install` to update the lock file.
+- `pyproject.toml`: key `project.version`
+- `Cargo.toml`: key `package.version`
+
+Once all versions are consistently updated create a version tag `vX.Y.Z` and
+push it. We trigger automatic publishing of releases for all tags.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-zeek"
 description = "Zeek grammar for tree-sitter"
-version = "0.0.1"
+version = "0.1.0"
 keywords = ["incremental", "parsing", "tree-sitter", "zeek"]
 classifiers = [
   "Intended Audience :: Developers",


### PR DESCRIPTION
The release workflow from #23 works and we now [successfully publish to PyPI](https://pypi.org/project/tree-sitter-zeek/). I however noticed that I did not make required updates to all files, so this PR fixes that and also adds documentation on how to do that.