### PR TITLE
Bring parser up to date with language changes in Zeek

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -431,7 +431,7 @@ module.exports = grammar({
 
     event_hdr: ($) => seq($.id, "(", optional($.expr_list), ")"),
 
-    id: () => /(([A-Za-z_][A-Za-z_0-9]*)?::)?[A-Za-z_][A-Za-z_0-9]*/,
+    id: () => /(::)?([A-Za-z_][A-Za-z_0-9]*)(::[A-Za-z_][A-Za-z_0-9]*)*/,
     file: ($) => /[^ \t\r\n]+/,
     pattern: ($) => /\/((\\\/)?[^\r\n\/]?)*\/i?/,
 

--- a/grammar.js
+++ b/grammar.js
@@ -1,3 +1,6 @@
+/// <reference types="tree-sitter-cli/dsl" />
+// @ts-check
+
 // Aliases that make things easier to read
 prec_r = prec.right;
 prec_l = prec.left;

--- a/grammar.js
+++ b/grammar.js
@@ -422,7 +422,11 @@ module.exports = grammar({
         seq("@ifndef", "(", $.id, ")"),
         "@endif",
         "@else",
+        $.pragma,
       ),
+
+    pragma: () =>
+      seq(token("@pragma"), choice("push", "pop"), /[A-Za-z0-9][A-Za-z0-9\-]*/),
 
     // These directives return strings.
     string_directive: ($) => choice("@DIR", "@FILENAME"),

--- a/grammar.js
+++ b/grammar.js
@@ -89,12 +89,10 @@ module.exports = grammar({
       seq(
         "redef",
         "record",
-        $.id,
-        "+=",
-        "{",
-        repeat($.type_spec),
-        "}",
-        optional($.attr_list),
+        choice(
+          seq($.id, "+=", "{", repeat($.type_spec), "}", optional($.attr_list)),
+          seq($.expr, "-=", "{", $.attr_list, "}"),
+        ),
         ";",
       ),
     type_decl: ($) =>
@@ -482,6 +480,8 @@ module.exports = grammar({
     // existing formatting in select places.
     nl: ($) => /\r?\n/,
   },
+
+  conflicts: ($) => [[$.expr, $.redef_record_decl]],
 
   extras: ($) => [
     /[ \t]+/,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -407,37 +407,72 @@
           "value": "record"
         },
         {
-          "type": "SYMBOL",
-          "name": "id"
-        },
-        {
-          "type": "STRING",
-          "value": "+="
-        },
-        {
-          "type": "STRING",
-          "value": "{"
-        },
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "SYMBOL",
-            "name": "type_spec"
-          }
-        },
-        {
-          "type": "STRING",
-          "value": "}"
-        },
-        {
           "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "attr_list"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "id"
+                },
+                {
+                  "type": "STRING",
+                  "value": "+="
+                },
+                {
+                  "type": "STRING",
+                  "value": "{"
+                },
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "type_spec"
+                  }
+                },
+                {
+                  "type": "STRING",
+                  "value": "}"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "attr_list"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
             },
             {
-              "type": "BLANK"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "expr"
+                },
+                {
+                  "type": "STRING",
+                  "value": "-="
+                },
+                {
+                  "type": "STRING",
+                  "value": "{"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "attr_list"
+                },
+                {
+                  "type": "STRING",
+                  "value": "}"
+                }
+              ]
             }
           ]
         },
@@ -4281,6 +4316,39 @@
         {
           "type": "STRING",
           "value": "@else"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "pragma"
+        }
+      ]
+    },
+    "pragma": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "@pragma"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "push"
+            },
+            {
+              "type": "STRING",
+              "value": "pop"
+            }
+          ]
+        },
+        {
+          "type": "PATTERN",
+          "value": "[A-Za-z0-9][A-Za-z0-9\\-]*"
         }
       ]
     },
@@ -4328,7 +4396,7 @@
     },
     "id": {
       "type": "PATTERN",
-      "value": "(([A-Za-z_][A-Za-z_0-9]*)?::)?[A-Za-z_][A-Za-z_0-9]*"
+      "value": "(::)?([A-Za-z_][A-Za-z_0-9]*)(::[A-Za-z_][A-Za-z_0-9]*)*"
     },
     "file": {
       "type": "PATTERN",
@@ -4452,7 +4520,12 @@
       "name": "minor_comment"
     }
   ],
-  "conflicts": [],
+  "conflicts": [
+    [
+      "expr",
+      "redef_record_decl"
+    ]
+  ],
   "precedences": [],
   "externals": [],
   "inline": [],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -739,6 +739,11 @@
     }
   },
   {
+    "type": "pragma",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "preproc_directive",
     "named": true,
     "fields": {},
@@ -756,6 +761,10 @@
         },
         {
           "type": "id",
+          "named": true
+        },
+        {
+          "type": "pragma",
           "named": true
         },
         {
@@ -821,6 +830,10 @@
       "types": [
         {
           "type": "attr_list",
+          "named": true
+        },
+        {
+          "type": "expr",
           "named": true
         },
         {
@@ -1277,6 +1290,10 @@
     "named": false
   },
   {
+    "type": "@pragma",
+    "named": false
+  },
+  {
     "type": "@prefixes",
     "named": false
   },
@@ -1493,6 +1510,10 @@
     "named": false
   },
   {
+    "type": "pop",
+    "named": false
+  },
+  {
     "type": "port",
     "named": true
   },
@@ -1502,6 +1523,10 @@
   },
   {
     "type": "print",
+    "named": false
+  },
+  {
+    "type": "push",
     "named": false
   },
   {

--- a/test/corpus/expressions
+++ b/test/corpus/expressions
@@ -40,25 +40,40 @@ f(1) + f(1);
   (nl))
 
 ================================================================================
-Global IDs
+IDs
 ================================================================================
 
-global x: ::X;
-global x: GLOBAL::X;
-
+a;
+a01231;
+a::b;
+::a;
+GLOBAL::a; # Legacy syntax.
+Cluster::Supervisor::__init_cluster_nodes();
 ---
 
 (source_file
   (nl)
-  (decl
-    (global_decl
-      (id)
-      (type
-        (id))))
+  (stmt
+    (expr
+      (id)))
   (nl)
-  (decl
-    (global_decl
-      (id)
-      (type
-        (id))))
-  (nl))
+  (stmt
+    (expr
+      (id)))
+  (nl)
+  (stmt
+    (expr
+      (id)))
+  (nl)
+  (stmt
+    (expr
+      (id)))
+  (nl)
+  (stmt
+    (expr
+      (id)))
+  (minor_comment)
+  (nl)
+  (stmt
+    (expr
+      (id))))

--- a/test/corpus/preproc
+++ b/test/corpus/preproc
@@ -1,0 +1,45 @@
+================================================================================
+Pragma
+================================================================================
+
+event run_sync_hook() {
+        hook Telemetry::sync();
+@pragma push ignore-deprecations
+        schedule sync_interval { run_sync_hook() };
+@pragma pop ignore-deprecations
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (nl)
+  (decl
+    (func_decl
+      (func_hdr
+        (event
+          (id)
+          (func_params)))
+      (func_body
+        (nl)
+        (stmt_list
+          (stmt
+            (expr
+              (expr
+                (id))))
+          (nl)
+          (stmt
+            (preproc_directive
+              (pragma)))
+          (nl)
+          (stmt
+            (expr
+              (expr
+                (id))
+              (event_hdr
+                (id))))
+          (nl)
+          (stmt
+            (preproc_directive
+              (pragma))))
+        (nl))))
+  (nl))

--- a/test/corpus/statements
+++ b/test/corpus/statements
@@ -31,3 +31,34 @@ assert 1 == 1;
         (constant
           (integer)))))
   (nl))
+
+================================================================================
+Redef record
+================================================================================
+
+redef record Foo += { foo: Info &optional; };
+redef record Conn::Info$ip_proto -= { &log };
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (nl)
+  (decl
+    (redef_record_decl
+      (id)
+      (type_spec
+        (id)
+        (type
+          (id))
+        (attr_list
+          (attr)))))
+  (nl)
+  (decl
+    (redef_record_decl
+      (expr
+        (expr
+          (id))
+        (id))
+      (attr_list
+        (attr))))
+  (nl))


### PR DESCRIPTION
This PR updates the grammar so it can parse all scripts in the base distribution again, namely:

- allow scoped IDs with more than two parts
- allow record redefs which remove field attributes
- add rudimentary support for `@pragma`