### PR TITLE
Remove explicit installation of tree-sitter CLI in CI check job

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: tree-sitter/setup-action/cli@v1
+      - uses: actions/setup-node@v4
+        with:
+          cache: npm
+          node-version: 20
+      - run: |
+          echo "$PWD/node_modules/tree-sitter-cli/" >> "$GITHUB_PATH"
+      - run: |
+          echo "$PWD"
+          ls -R "$PWD"
+          echo "$GITHUB_PATH"
+          cat "$GITHUB_PATH"
+          which tree-sitter
       - uses: tree-sitter/parser-test-action@v2
         with:
           generate: true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           cache: npm
           node-version: 20
+      - run: npm ci
       - run: |
           echo "$PWD/node_modules/tree-sitter-cli/" >> "$GITHUB_PATH"
       - run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,6 +21,8 @@ jobs:
           ls -R "$PWD"
           echo "$GITHUB_PATH"
           cat "$GITHUB_PATH"
+          echo "$NODE_PATH"
+          ls -R "$NODE_PATH"
           which tree-sitter
       - uses: tree-sitter/parser-test-action@v2
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,6 +15,7 @@ jobs:
           cache: npm
           node-version: 20
       - run: npm ci
+      - run: which tree-sitter || true
       - run: |
           echo "$PWD/node_modules/tree-sitter-cli/" >> "$GITHUB_PATH"
       - run: |
@@ -22,8 +23,6 @@ jobs:
           ls -R "$PWD"
           echo "$GITHUB_PATH"
           cat "$GITHUB_PATH"
-          echo "$NODE_PATH"
-          ls -R "$NODE_PATH"
           which tree-sitter
       - uses: tree-sitter/parser-test-action@v2
         with:


### PR DESCRIPTION
The GH action `tree-sitter/setup-action/cli` defaults to using the latest version of tree-sitter while we already already capture the tree-sitter version we build against in `package.json`. This duplication was not only unnecessary, but it also lead to version conflicts when checking whether generated files were up-to-date. This instead uses the tree-sitter CLI version as encoded for npm.