### PR TITLE
Bump version of tree-sitter-cli

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "prebuildify": "^6.0.0",
-        "tree-sitter-cli": "^0.25.2"
+        "tree-sitter-cli": "^0.25.3"
       },
       "peerDependencies": {
         "tree-sitter": "^0.22.4"
@@ -347,9 +347,9 @@
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.25.2",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.25.2.tgz",
-      "integrity": "sha512-bjzYIsoy/3+r/7cYvJ+l1G/FrCe6IrxvlF/NUb6TkWAsKrCnh1KKvpmKGtRl/yY82axBf+OLI3omiVwlOhOsTw==",
+      "version": "0.25.3",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.25.3.tgz",
+      "integrity": "sha512-Bk6ZUXG+cKnwZpfR/te4NDrKld90p6350eqWlbLwSpV9/8vmL/x8LCw+3k7quY9oMDaYoMXHMvokXJbkM5A7bA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     }
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.25.2",
+    "tree-sitter-cli": "^0.25.3",
     "prebuildify": "^6.0.0"
   },
   "tree-sitter": [


### PR DESCRIPTION
CI seems to not use the version from the lock file, but instead the following patch version. This creates incompatibilities between running `./node_modules/tree-sitter-cli/tree-sitter generate` and CI.

Bump the locked version to avoid the mismatch.