### PR TITLE
Add in separate `type_expr` for formatting

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -350,7 +350,7 @@ module.exports = grammar({
         $.id,
         $.constant,
         $.pattern,
-        $._simple_type,
+        alias($._simple_type, $.type),
 
         seq("(", $.expr, ")"),
         seq("copy", "(", $.expr, ")"),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3556,8 +3556,13 @@
           "name": "pattern"
         },
         {
-          "type": "SYMBOL",
-          "name": "_simple_type"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_simple_type"
+          },
+          "named": true,
+          "value": "type"
         },
         {
           "type": "SEQ",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -389,10 +389,6 @@
           "named": true
         },
         {
-          "type": "enum_body",
-          "named": true
-        },
-        {
           "type": "event_hdr",
           "named": true
         },
@@ -422,10 +418,6 @@
         },
         {
           "type": "type",
-          "named": true
-        },
-        {
-          "type": "type_spec",
           "named": true
         }
       ]

--- a/test/corpus/expressions
+++ b/test/corpus/expressions
@@ -120,7 +120,14 @@ print table[int] of vector of table[string] of count;
   (nl)
   (stmt
     (expr_list
-      (expr)))
+      (expr
+        (type))))
+  (nl)
+  (stmt
+    (expr_list
+      (expr
+        (type
+          (type)))))
   (nl)
   (stmt
     (expr_list
@@ -129,13 +136,10 @@ print table[int] of vector of table[string] of count;
   (nl)
   (stmt
     (expr_list
-      (expr)))
-  (nl)
-  (stmt
-    (expr_list
       (expr
-        (type)
         (type
+          (type)
           (type
-            (type)
-            (type)))))))
+            (type
+              (type)
+              (type))))))))


### PR DESCRIPTION
~This will let the formatter treat `type_expr` with the type formatter so it's all treated the same.~

Alias to `type` so the formatter can easily pick up type formatting with expressions