### PR TITLE
Fix `&deprecated=<string>` in enum decls

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -231,12 +231,7 @@ module.exports = grammar({
     enum_body: ($) => list1($.enum_body_elem, ",", true),
 
     enum_body_elem: ($) =>
-      choice(
-        seq($.id, "=", $.constant, optional($.deprecated)),
-        seq($.id, optional($.deprecated)),
-      ),
-
-    deprecated: ($) => choice("&deprecated", seq("&deprecated", "=", "const")),
+      seq($.id, optional(seq("=", $.constant)), optional($.attr)),
 
     func_params: ($) =>
       choice(seq("(", $.formal_args, ")", optional(seq(":", $.type)))),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1937,81 +1937,42 @@
       ]
     },
     "enum_body_elem": {
-      "type": "CHOICE",
+      "type": "SEQ",
       "members": [
         {
-          "type": "SEQ",
+          "type": "SYMBOL",
+          "name": "id"
+        },
+        {
+          "type": "CHOICE",
           "members": [
             {
-              "type": "SYMBOL",
-              "name": "id"
-            },
-            {
-              "type": "STRING",
-              "value": "="
-            },
-            {
-              "type": "SYMBOL",
-              "name": "constant"
-            },
-            {
-              "type": "CHOICE",
+              "type": "SEQ",
               "members": [
                 {
-                  "type": "SYMBOL",
-                  "name": "deprecated"
+                  "type": "STRING",
+                  "value": "="
                 },
                 {
-                  "type": "BLANK"
+                  "type": "SYMBOL",
+                  "name": "constant"
                 }
               ]
+            },
+            {
+              "type": "BLANK"
             }
           ]
         },
         {
-          "type": "SEQ",
+          "type": "CHOICE",
           "members": [
             {
               "type": "SYMBOL",
-              "name": "id"
+              "name": "attr"
             },
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "deprecated"
-                },
-                {
-                  "type": "BLANK"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    "deprecated": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "&deprecated"
-        },
-        {
-          "type": "SEQ",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "&deprecated"
-            },
-            {
-              "type": "STRING",
-              "value": "="
-            },
-            {
-              "type": "STRING",
-              "value": "const"
+              "type": "BLANK"
             }
           ]
         }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -269,11 +269,6 @@
     }
   },
   {
-    "type": "deprecated",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "enum_body",
     "named": true,
     "fields": {},
@@ -297,11 +292,11 @@
       "required": true,
       "types": [
         {
-          "type": "constant",
+          "type": "attr",
           "named": true
         },
         {
-          "type": "deprecated",
+          "type": "constant",
           "named": true
         },
         {
@@ -1404,11 +1399,11 @@
   },
   {
     "type": "file",
-    "named": false
+    "named": true
   },
   {
     "type": "file",
-    "named": true
+    "named": false
   },
   {
     "type": "floatp",
@@ -1510,11 +1505,11 @@
   },
   {
     "type": "pattern",
-    "named": false
+    "named": true
   },
   {
     "type": "pattern",
-    "named": true
+    "named": false
   },
   {
     "type": "pop",
@@ -1522,11 +1517,11 @@
   },
   {
     "type": "port",
-    "named": false
+    "named": true
   },
   {
     "type": "port",
-    "named": true
+    "named": false
   },
   {
     "type": "print",

--- a/test/corpus/types
+++ b/test/corpus/types
@@ -49,3 +49,77 @@ Address
     (expr
       (constant
         (ipv6)))))
+
+================================================================================
+Enum with deprecated
+================================================================================
+
+type enum_with_deprecated_explicit: enum {
+    ZERO_EXPLICIT = 0,
+    ONE_EXPLICIT = 1 &deprecated,
+    TWO_EXPLICIT = 2 &deprecated="two is deprecated :(",
+    THREE_EXPLICIT = 3,
+};
+
+type enum_with_deprecated_implicit: enum {
+    ZERO_IMPLICIT,
+    ONE_IMPLICIT &deprecated,
+    TWO_IMPLICIT &deprecated="two is deprecated :(",
+    THREE_IMPLICIT,
+};
+--------------------------------------------------------------------------------
+
+(source_file
+  (nl)
+  (decl
+    (type_decl
+      (id)
+      (type
+        (nl)
+        (enum_body
+          (enum_body_elem
+            (id)
+            (constant
+              (integer)))
+          (nl)
+          (enum_body_elem
+            (id)
+            (constant
+              (integer))
+            (attr))
+          (nl)
+          (enum_body_elem
+            (id)
+            (constant
+              (integer))
+            (attr
+              (string)))
+          (nl)
+          (enum_body_elem
+            (id)
+            (constant
+              (integer))))
+        (nl))))
+  (nl)
+  (nl)
+  (decl
+    (type_decl
+      (id)
+      (type
+        (nl)
+        (enum_body
+          (enum_body_elem
+            (id))
+          (nl)
+          (enum_body_elem
+            (id)
+            (attr))
+          (nl)
+          (enum_body_elem
+            (id)
+            (attr
+              (string)))
+          (nl)
+          (enum_body_elem
+            (id)))
+        (nl)))))


### PR DESCRIPTION
Found in https://github.com/zeek/zeekscript/pull/116

I just swapped enums to accept attributes on each body element, I figured we'd rather be more permissive. This will also remove the separate case for `&deprecated` from attributes