### PR TITLE
Avoid referencing `tree-sitter-zeek-src`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,11 @@ similars.
 
 To use the generated parser directly (e.g. via any of tree-sitter's
 [language bindings](https://tree-sitter.github.io/tree-sitter/#language-bindings)),
-clone this repository recursively. We maintain a separate
-[git repository](https://github.com/zeek/tree-sitter-zeek-src)
-to track generated sources. You do not need the tree-sitter CLI
-to use those sources in your tooling, but you'll likely want it
-anyway to explore the parser. For example, `tree-sitter parse <script>`
-produces the script's syntax tree, and `tree-sitter highlight <script>`
-shows syntax-highlighted sources.
+clone this repository recursively. Generated sources are tracked in the
+[`src`](src/) directory. You do not need the tree-sitter CLI to use those
+sources in your tooling, but you'll likely want it anyway to explore the parser.
+For example, `tree-sitter parse <script>` produces the script's syntax tree, and
+`tree-sitter highlight <script>` shows syntax-highlighted sources.
 
 ## Building the parser
 


### PR DESCRIPTION
This just replaces the reference to https://github.com/zeek/tree-sitter-zeek-src with the `src` directory

The rest of the changes are just fixing line lengths ¯\\\_(ツ)_/¯