### PR TITLE
Fix Go module path to match hosting location

### DIFF
--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tree_sitter "github.com/tree-sitter/go-tree-sitter"
-	tree_sitter_zeek "github.com/tree-sitter/tree-sitter-zeek/bindings/go"
+	tree_sitter_zeek "github.com/zeek/tree-sitter-zeek/bindings/go"
 )
 
 func TestCanLoadGrammar(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tree-sitter/tree-sitter-zeek
+module github.com/zeek/tree-sitter-zeek
 
 go 1.23
 


### PR DESCRIPTION
`go.mod` declares `module github.com/tree-sitter/tree-sitter-zeek`, but the grammar is hosted at `github.com/zeek/tree-sitter-zeek`. Since Go resolves modules by their declared path, the module can't be consumed under either name — the `zeek/` path is rejected as a mismatch, and the `tree-sitter/` path 404s on GitHub and is absent from the module proxy:

```console
$ go get github.com/zeek/tree-sitter-zeek@v0.2.15
go: github.com/zeek/tree-sitter-zeek@v0.2.15 requires
	github.com/zeek/tree-sitter-zeek@v0.2.15: parsing go.mod:
	module declares its path as: github.com/tree-sitter/tree-sitter-zeek
	        but was required as: github.com/zeek/tree-sitter-zeek
```

The only workaround is a `replace` directive in each consuming module, which doesn't carry transitively — so any library depending on this grammar pushes the workaround onto its own users.

This points the module path and the Go binding test import at the `zeek/` org, matching `pyproject.toml` (corrected in #71). With the patch, `go test ./bindings/go/...` passes as `github.com/zeek/tree-sitter-zeek/bindings/go` and a fresh consumer module can import and load the grammar.

Despite `bindings/**` being `linguist-generated`, this won't be reverted by `tree-sitter generate` or the monthly `update.yml` run: the CLI writes `go.mod` and `binding_test.go` via `missing_path`, which only fires when the file is absent.

`Cargo.toml` (`repository`) and `CMakeLists.txt` (`HOMEPAGE_URL`) still carry the stale `tree-sitter/` URL. Those are cosmetic rather than resolution failures so I left them out — happy to fold them in here or as a follow-up.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
