### PR TITLE
Regenerate with 0.26.11 and "upgrade"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: tree-sitter/setup-action/cli@v2
+        with:
+          tree-sitter-ref: v0.26.11
       - uses: tree-sitter/parser-test-action@v3
         with:
           generate: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "prebuildify": "^6.0.0",
-        "tree-sitter-cli": "^0.26.8"
+        "tree-sitter-cli": "^0.26.11"
       },
       "peerDependencies": {
         "tree-sitter": "^0.22.4"
@@ -347,8 +347,8 @@
       }
     },
     "node_modules/tree-sitter-cli": {
-      "version": "0.26.8",
-      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.26.8.tgz",
+      "version": "0.26.11",
+      "resolved": "https://registry.npmjs.org/tree-sitter-cli/-/tree-sitter-cli-0.26.11.tgz",
       "integrity": "sha512-teQFMF5V/g8aIdakZ0M/eZoedCM3MuBt1JuDOICLloA2hy7QfeOInb99U6wiML4qXcBHWREwf0U1TWzw7p67YA==",
       "dev": true,
       "hasInstallScript": true,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     }
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.26.8",
+    "tree-sitter-cli": "^0.26.11",
     "prebuildify": "^6.0.0"
   },
   "tree-sitter": [

--- a/src/parser.c
+++ b/src/parser.c
@@ -5809,7 +5809,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '#') ADVANCE(1410);
       if (lookahead == '\t' ||
           lookahead == ' ') SKIP(30);
-      if (lookahead != 0) ADVANCE(1415);
+      if (lookahead != 0 &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(1415);
       END_STATE();
     case 31:
       if (lookahead == '"') ADVANCE(1469);
@@ -5817,7 +5819,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('0' <= lookahead && lookahead <= '7')) ADVANCE(31);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(33);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(33);
       END_STATE();
     case 32:
       if (lookahead == '"') ADVANCE(1469);
@@ -5827,14 +5831,18 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           ('a' <= lookahead && lookahead <= 'f')) ADVANCE(32);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(33);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(33);
       END_STATE();
     case 33:
       if (lookahead == '"') ADVANCE(1469);
       if (lookahead == '\\') ADVANCE(539);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(33);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(33);
       END_STATE();
     case 34:
       if (lookahead == '+') ADVANCE(555);
@@ -6033,7 +6041,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\\') ADVANCE(559);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(68);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(68);
       END_STATE();
     case 69:
       if (lookahead == '2') ADVANCE(43);
@@ -7564,7 +7574,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (('0' <= lookahead && lookahead <= '7')) ADVANCE(31);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(33);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(33);
       END_STATE();
     case 540:
       if (lookahead == 'x') ADVANCE(481);
@@ -7633,7 +7645,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 559:
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(68);
+          lookahead != '\n' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(68);
       END_STATE();
     case 560:
       if (eof) ADVANCE(574);
@@ -10115,7 +10129,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '\\') ADVANCE(559);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(68);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(68);
       END_STATE();
     case 830:
       ACCEPT_TOKEN(anon_sym_PERCENT);
@@ -10311,7 +10327,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '<') ADVANCE(864);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(864);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(864);
       END_STATE();
     case 862:
       ACCEPT_TOKEN(aux_sym_preproc_directive_token1);
@@ -10321,20 +10339,26 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(864);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(864);
       END_STATE();
     case 863:
       ACCEPT_TOKEN(aux_sym_preproc_directive_token1);
       if (lookahead == '#') ADVANCE(861);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(864);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(864);
       END_STATE();
     case 864:
       ACCEPT_TOKEN(aux_sym_preproc_directive_token1);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(864);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(864);
       END_STATE();
     case 865:
       ACCEPT_TOKEN(anon_sym_ATload);
@@ -15989,7 +16013,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(1414);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(1414);
       END_STATE();
     case 1410:
       ACCEPT_TOKEN(sym_file);
@@ -15999,7 +16025,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(1411);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(1411);
       END_STATE();
     case 1411:
       ACCEPT_TOKEN(sym_file);
@@ -16008,7 +16036,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(1411);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(1411);
       END_STATE();
     case 1412:
       ACCEPT_TOKEN(sym_file);
@@ -16017,7 +16047,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(1412);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(1412);
       END_STATE();
     case 1413:
       ACCEPT_TOKEN(sym_file);
@@ -16026,7 +16058,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(1413);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(1413);
       END_STATE();
     case 1414:
       ACCEPT_TOKEN(sym_file);
@@ -16035,7 +16069,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0 &&
           lookahead != '\t' &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(1414);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(1414);
       END_STATE();
     case 1415:
       ACCEPT_TOKEN(sym_file);
@@ -16043,7 +16079,9 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
           lookahead != '\t' &&
           lookahead != '\n' &&
           lookahead != '\r' &&
-          lookahead != ' ') ADVANCE(1415);
+          lookahead != ' ' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(1415);
       END_STATE();
     case 1416:
       ACCEPT_TOKEN(sym_pattern);
@@ -16475,13 +16513,17 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_zeekygen_head_comment);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(1470);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(1470);
       END_STATE();
     case 1471:
       ACCEPT_TOKEN(sym_zeekygen_prev_comment);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(1471);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(1471);
       END_STATE();
     case 1472:
       ACCEPT_TOKEN(sym_zeekygen_next_comment);
@@ -16489,26 +16531,34 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == '<') ADVANCE(1471);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(1473);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(1473);
       END_STATE();
     case 1473:
       ACCEPT_TOKEN(sym_zeekygen_next_comment);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(1473);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(1473);
       END_STATE();
     case 1474:
       ACCEPT_TOKEN(sym_minor_comment);
       if (lookahead == '#') ADVANCE(1472);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(1475);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(1475);
       END_STATE();
     case 1475:
       ACCEPT_TOKEN(sym_minor_comment);
       if (lookahead != 0 &&
           lookahead != '\n' &&
-          lookahead != '\r') ADVANCE(1475);
+          lookahead != '\r' &&
+          lookahead != 0x17f &&
+          lookahead != 0x212a) ADVANCE(1475);
       END_STATE();
     case 1476:
       ACCEPT_TOKEN(sym_nl);

--- a/src/tree_sitter/array.h
+++ b/src/tree_sitter/array.h
@@ -50,12 +50,18 @@ extern "C" {
 /// memory allocated for the array's contents.
 #define array_clear(self) ((self)->size = 0)
 
+#ifdef __cplusplus
+#define _array__cast(self, expr) (decltype((self)->contents))(expr)
+#else
+#define _array__cast(self, expr) (expr)
+#endif
+
 /// Reserve `new_capacity` elements of space in the array. If `new_capacity` is
 /// less than the array's current capacity, this function has no effect.
-#define array_reserve(self, new_capacity)        \
-  ((self)->contents = _array__reserve(           \
-    (void *)(self)->contents, &(self)->capacity, \
-    array_elem_size(self), new_capacity)         \
+#define array_reserve(self, new_capacity)                 \
+  ((self)->contents = _array__cast(self, _array__reserve( \
+    (void *)(self)->contents, &(self)->capacity,          \
+    array_elem_size(self), new_capacity))                 \
   )
 
 /// Free any memory allocated for this array. Note that this does not free any
@@ -71,10 +77,10 @@ extern "C" {
 /// Push a new `element` onto the end of the array.
 #define array_push(self, element)                                 \
   do {                                                            \
-    (self)->contents = _array__grow(                              \
+    (self)->contents = _array__cast(self, _array__grow(           \
       (void *)(self)->contents, (self)->size, &(self)->capacity,  \
       1, array_elem_size(self)                                    \
-    );                                                            \
+    ));                                                           \
    (self)->contents[(self)->size++] = (element);                  \
   } while(0)
 
@@ -83,10 +89,10 @@ extern "C" {
 #define array_grow_by(self, count)                                               \
   do {                                                                           \
     if ((count) == 0) break;                                                     \
-    (self)->contents = _array__grow(                                             \
+    (self)->contents = _array__cast(self, _array__grow(                          \
       (self)->contents, (self)->size, &(self)->capacity,                         \
       count, array_elem_size(self)                                               \
-    );                                                                           \
+    ));                                                                          \
     memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
     (self)->size += (count);                                                     \
   } while (0)
@@ -98,26 +104,26 @@ extern "C" {
 /// Append `count` elements to the end of the array, reading their values from the
 /// `contents` pointer.
 #define array_extend(self, count, other_contents)                 \
-  (self)->contents = _array__splice(                              \
+  ((self)->contents = _array__cast(self, _array__splice(          \
     (void*)(self)->contents, &(self)->size, &(self)->capacity,    \
     array_elem_size(self), (self)->size, 0, count, other_contents \
-  )
+  )))
 
 /// Remove `old_count` elements from the array starting at the given `index`. At
 /// the same index, insert `new_count` new elements, reading their values from the
 /// `new_contents` pointer.
 #define array_splice(self, _index, old_count, new_count, new_contents) \
-  (self)->contents = _array__splice(                                   \
+  ((self)->contents = _array__cast(self, _array__splice(              \
     (void *)(self)->contents, &(self)->size, &(self)->capacity,        \
     array_elem_size(self), _index, old_count, new_count, new_contents  \
-  )
+  )))
 
 /// Insert one `element` into the array at the given `index`.
 #define array_insert(self, _index, element)                     \
-  (self)->contents = _array__splice(                            \
+  ((self)->contents = _array__cast(self, _array__splice(        \
     (void *)(self)->contents, &(self)->size, &(self)->capacity, \
     array_elem_size(self), _index, 0, 1, &(element)             \
-  )
+  )))
 
 /// Remove one element from the array at the given `index`.
 #define array_erase(self, _index) \
@@ -128,17 +134,17 @@ extern "C" {
 
 /// Assign the contents of one array to another, reallocating if necessary.
 #define array_assign(self, other)                                   \
-  (self)->contents = _array__assign(                                \
+  ((self)->contents = _array__cast(self, _array__assign(            \
     (void *)(self)->contents, &(self)->size, &(self)->capacity,     \
     (const void *)(other)->contents, (other)->size, array_elem_size(self) \
-  )
+  )))
 
 /// Swap one array with another
 #define array_swap(self, other)                                     \
   do {                                                              \
     void *_array_swap_tmp = (void *)(self)->contents;               \
     (self)->contents = (other)->contents;                           \
-    (other)->contents = _array_swap_tmp;                            \
+    (other)->contents = _array__cast(other, _array_swap_tmp);       \
     _array__swap(&(self)->size, &(self)->capacity,                  \
                  &(other)->size, &(other)->capacity);               \
   } while (0)


### PR DESCRIPTION
Found since #80 had unrelated failing tests

CI wasn't given a version number, so it would just use `latest`. This caused tests to fail, so pin the version. We can upgrade it when we upgrade the rest of it.

It also bumps the ^0.26.8 dep in package.json, just to show the tested version. Even though it should do nothing.

chatted with claude about it who ran the parser update without me telling it to. shame. (confirmed with `npm exec -- tree-sitter generate`)